### PR TITLE
Some docs housekeeping.

### DIFF
--- a/docs/footer.rst
+++ b/docs/footer.rst
@@ -14,7 +14,7 @@
             <textarea id="maths-test-answer" rows="1" cols="5"></textarea>
          </div>
 
-         <form method="post" target="feedback_print_popup" action="https://artifex.com/contributor/mupdfjs-process-feedback.php" onsubmit="submitFeedback();">
+         <form method="post" target="feedback_print_popup" action="https://artifex.com/contributor/mupdfnet-process-feedback.php" onsubmit="submitFeedback();">
              <input type="hidden" name="url" id="feedback-doc-url-page">
              <input type="hidden" name="page" id="feedback-page-ref">
              <input type="hidden" name="helpful" id="feedback-helpful">
@@ -125,17 +125,6 @@
 
    </script>
 
-
-
-.. note - this ensures that the Sphinx build system will pull in the image (as it is referenced in an RST file) to _images,
-   we don't want to display it via rst markup due to limitations (hence width:0), however we do want it available for our raw HTML
-   which we use in header.rst.
-
-.. image:: images/discord-mark-blue.svg
-          :alt:
-          :width: 0
-          :height: 0
-          :target: https://discord.gg/DQ8GBG6V4g
 
 
 

--- a/docs/header.rst
+++ b/docs/header.rst
@@ -50,7 +50,18 @@
     <div style="display:flex;justify-content:space-between;align-items:center;margin-top:20px;">
         <div class="discordLink" style="display:flex;align-items:center;margin-top: -5px;">
             <a href="https://discord.gg/DQ8GBG6V4g" id="findOnDiscord" target=_blank>Find <b>#mupdf_net</b> on <b>Discord</b></a>
-            <a href="https://discord.gg/DQ8GBG6V4g" target=_blank><img src="https://pymupdf.readthedocs.io/en/latest/_images/discord-mark-blue.svg" alt="Discord logo" /></a>
+            <a href="https://discord.gg/DQ8GBG6V4g" target=_blank>
+                <div style="width:30px;height:30px;margin-left:5px;">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 127.14 96.36">
+                        <defs>
+                            <style>.discordLogoFill{fill:#5865f2;}</style>
+                        </defs>
+                        <g id="Discord_Logo" data-name="Discord Logo">
+                            <path class="discordLogoFill" d="M107.7,8.07A105.15,105.15,0,0,0,81.47,0a72.06,72.06,0,0,0-3.36,6.83A97.68,97.68,0,0,0,49,6.83,72.37,72.37,0,0,0,45.64,0,105.89,105.89,0,0,0,19.39,8.09C2.79,32.65-1.71,56.6.54,80.21h0A105.73,105.73,0,0,0,32.71,96.36,77.7,77.7,0,0,0,39.6,85.25a68.42,68.42,0,0,1-10.85-5.18c.91-.66,1.8-1.34,2.66-2a75.57,75.57,0,0,0,64.32,0c.87.71,1.76,1.39,2.66,2a68.68,68.68,0,0,1-10.87,5.19,77,77,0,0,0,6.89,11.1A105.25,105.25,0,0,0,126.6,80.22h0C129.24,52.84,122.09,29.11,107.7,8.07ZM42.45,65.69C36.18,65.69,31,60,31,53s5-12.74,11.43-12.74S54,46,53.89,53,48.84,65.69,42.45,65.69Zm42.24,0C78.41,65.69,73.25,60,73.25,53s5-12.74,11.44-12.74S96.23,46,96.12,53,91.08,65.69,84.69,65.69Z"/>
+                        </g>
+                    </svg>
+                </div>
+            </a>
         </div>
 
         <div class="feedbackLink"><a id="feedbackLinkTop" target=_blank>Do you have any feedback on this page?</b></a></div>

--- a/docs/the-basics/index.rst
+++ b/docs/the-basics/index.rst
@@ -866,6 +866,7 @@ The following snippet creates a new |PDF| and encrypts it with separate user and
 
 
 .. code-block:: csharp
+
     using MuPDF.NET;
 
     string text = "some secret information"; // keep this data secret


### PR DESCRIPTION
- Fixes the broken Discord image
- Fixes a code block display issue
- Fixes the feedback form URL

The broken Discord image was a side-effect of PyMuPDF docs recently removing it's Discord logo ( and this repo was sourcing the image from pymupdf docs which was bad )

A missing carriage return was prevented a code block to appear in "The Basics" section

The feedback from URL at the footer referenced the MuPDF JS URL.