### PR TITLE
added updates to fix issue #140

### DIFF
--- a/MuPDF.NET/Page.cs
+++ b/MuPDF.NET/Page.cs
@@ -3131,7 +3131,7 @@ namespace MuPDF.NET
         )
         {
             if (matrix == null)
-                matrix = new Matrix();
+                matrix = new Matrix(1.0f, 1.0f);
 
             float zoom;
             if (dpi != 0)


### PR DESCRIPTION
- added the initial params into Matrix object in GetPixmap() function, to avoid exception in MuPDF.
- tested it in unit-test
![image](https://github.com/user-attachments/assets/4ffc891f-df08-4b5f-8145-cc1f73f3e084)
